### PR TITLE
Formatting additions, repositories handling and some python3 compatibility changes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@ LABEL MAINTAINERS="Daniel P. Smith <dpsmith@apertussolutions.com>"
 RUN apk add --no-cache \
     git \
     jq \
-    py2-pygit2 \
-    py2-requests \
+    py3-pygit2 \
+    py3-requests \
   && apk add --no-cache --virtual .makedepends \
-    py2-pip \
-  && pip install --no-cache-dir --upgrade pip \
-  && pip install --no-cache-dir sh \
+    py3-pip \
+  && pip3 install --no-cache-dir --upgrade pip \
+  && pip3 install --no-cache-dir sh \
   && apk del -r --no-cache .makedepends
 
 ADD generate_release.py /release/

--- a/generate_release.py
+++ b/generate_release.py
@@ -171,11 +171,12 @@ class Repository:
             print(e)
             raise Error
 
-        try:
-            sh.git.clone("--mirror", self.url, self.repodir)
-        except sh.ErrorReturnCode:
-            sys.stderr.write("Failed to mirror repo url: %s\n" % self.url)
-            raise Error
+        if not os.path.isdir(self.repodir):
+            try:
+                sh.git.clone("--mirror", self.url, self.repodir)
+            except sh.ErrorReturnCode:
+                sys.stderr.write("Failed to mirror repo url: %s\n" % self.url)
+                raise Error
 
         try:
             repo_path = pygit2.discover_repository(self.repodir)

--- a/generate_release.py
+++ b/generate_release.py
@@ -157,8 +157,8 @@ class Repository:
 
         # Check the remote for refs before attempting anything
         try:
-            pc = sh.wc(sh.git("ls-remote", "--heads", self.GITHUB_URL + repo_name, previous), "-l").stdout.decode('utf-8').strip()
-            nc = sh.wc(sh.git("ls-remote", "--heads", self.GITHUB_URL + repo_name, new), "-l").stdout.decode('utf-8').strip()
+            pc = sh.wc(sh.git("ls-remote", "--heads", "--tags", self.GITHUB_URL + repo_name, previous), "-l").stdout.decode('utf-8').strip()
+            nc = sh.wc(sh.git("ls-remote", "--heads", "--tags", self.GITHUB_URL + repo_name, new), "-l").stdout.decode('utf-8').strip()
 
             if pc == "0":
                 sys.stderr.write("No tag or head %s for repository %s\n", previous, self.GITHUB_URL + repo_name)

--- a/generate_release.py
+++ b/generate_release.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # The MIT License (MIT)
 # Copyright (c) 2017 Apertus Solutions, LLC

--- a/generate_release.py
+++ b/generate_release.py
@@ -282,10 +282,11 @@ class Release:
         self.contributors = list(set(self.contributors))
 
 class ReleaseDocument:
-    def __init__(self, filepath="release.adoc", relnum="X.Y.Z", author="Author Name", email="author@email.com", rev="1.0", rev_string="First"):
+    def __init__(self, filepath="release.adoc", relnum="X.Y.Z", author="Author Name", email="author@email.com", entity="copyright holding entity", rev="1.0", rev_string="First"):
         self.relnum = relnum
         self.author = author
         self.email = email
+        self.entity = entity
         self.rev = rev
         self.rev_string = rev_string
 
@@ -442,8 +443,8 @@ class ReleaseDocument:
         fd = self.fd
 
         fd.write("[appendix]\nLicense\n-------\n")
-        fd.write("Copyright 2017 by <copyright holding entity>. ")
-        fd.write("Created by %s <%s>." % (self.author, self.email))
+        fd.write("Copyright %s by <%s>. " % (datetime.now().year, self.entity))
+        fd.write("Created by %s <%s>. " % (self.author, self.email))
         fd.write("This work is licensed under the Creative Commons " +
                  "Attribution 4.0 International License. To view a copy of " +
                  "this license, visit http://creativecommons.org/licenses/by/4.0/.\n")
@@ -474,6 +475,8 @@ def main(base_path, out, refs, publish, bodies, gen_json=False):
         doc.author = publish['author']
     if publish['email']:
         doc.email = publish['email']
+    if publish['entity']:
+        doc.entity = publish['entity']
 
     doc.header_page()
     doc.platform_page(bodies['platform'])
@@ -492,6 +495,7 @@ if __name__ == '__main__':
     parser.add_argument("-p", "--path", help="directory where git repositories will be stored")
     parser.add_argument("-A", "--author", help="author's name")
     parser.add_argument("-E", "--email", help="author's email")
+    parser.add_argument("-G", "--entity", help="copyright holding entity")
     parser.add_argument("-R", "--relnum", help="release version number")
     parser.add_argument("-P", "--platform", help="path to file with \"Platform\" body")
     parser.add_argument("-T", "--testing", help="path to file with \"Testing\" body")
@@ -516,6 +520,7 @@ if __name__ == '__main__':
 
     publish['author'] = args.author if args.author else ""
     publish['email'] = args.email if args.email else ""
+    publish['entity'] = args.entity if args.entity else ""
     publish['relnum'] = args.relnum if args.relnum else ""
 
     bodies['platform'] = args.platform if args.platform else ""

--- a/generate_release.py
+++ b/generate_release.py
@@ -41,7 +41,7 @@ class Issues:
 
     @staticmethod
     def get_issue(issue):
-        if not Issues.issues.has_key(issue):
+        if not issue in Issues.issues:
             url = "https://openxt.atlassian.net/rest/api/latest/issue/" + issue
             try:
                 r = requests.get(url)
@@ -206,7 +206,7 @@ class Repository:
             if Commit.is_merge(c):
                 continue
 
-            if not self.authors.has_key(c.author_email):
+            if not c.author_email in self.authors:
                 self.authors[c.author_email] = c.author_name
 
             for s in c.signers:

--- a/generate_release.py
+++ b/generate_release.py
@@ -157,8 +157,8 @@ class Repository:
 
         # Check the remote for refs before attempting anything
         try:
-            pc = sh.wc(sh.git("ls-remote", "--heads", self.GITHUB_URL + repo_name, previous), "-l").stdout.strip()
-            nc = sh.wc(sh.git("ls-remote", "--heads", self.GITHUB_URL + repo_name, new), "-l").stdout.strip()
+            pc = sh.wc(sh.git("ls-remote", "--heads", self.GITHUB_URL + repo_name, previous), "-l").stdout.decode('utf-8').strip()
+            nc = sh.wc(sh.git("ls-remote", "--heads", self.GITHUB_URL + repo_name, new), "-l").stdout.decode('utf-8').strip()
 
             if pc == "0" or nc == "0":
                 raise Error
@@ -183,7 +183,7 @@ class Repository:
         self.commits = []
 
         try:
-            cherry = filter(None, sh.git.cherry(self.previous, self.new, _cwd=self.repodir).stdout.split("\n"))
+            cherry = filter(None, sh.git.cherry(self.previous, self.new, _cwd=self.repodir).stdout.decode('utf-8').split("\n"))
             cherry = filter(lambda i: i[0] == "+", cherry)
             if cherry:
                 commit_list = [x[2:].strip() for x in cherry]


### PR DESCRIPTION
After playing around with the script I ended up with the following changes.
I did not use the Docker container, hence the Python3 differences I guess. If use of recent Python releases is not desired, I can re-open a PR without them.

### Python3 related:
- Convert `dict.has_key` calls to `in` operator.
- `sh` module: decode `stdout` `bytes` objects.

### Cosmetic
- Add more detailed messages when a repository does not have a tag. 

### Git
- Handle release tags when calling `git ls-remote` (`--tags`). This would be used for releases.

### Functional changes:
- Copyright notice: Get current year from `datetime`
- Copyright notice: Add `-G` command-line option to pass the copyright holding entity for the notice
- Repositories blacklist: Some repositories in the OpenXT organisation do not follow the release scheme of the main project. Blacklist them.
- Do not create a git repository mirror if the directory of that mirror already exists. This allows the script to be called again with the same local mirrors. 